### PR TITLE
fix documentation for README.md and Physics files

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Once saved, this will parse and load the environment variables from the .env fil
 
 Consult [`src/config.ts`](./src/config.ts) for configuration, and [`package.json`](./package.json) for more environment variable setup.
 
+To close the server for local ports, you may press `Ctrl` + `C`.
+
 ## Discord Chat
 
 For support or discussion, please join our [online Discord chat](https://discord.gg/SyxWdxgHnT).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This builds and runs the server.
 
 After running the server, content will be served at `localhost:PORT` on your computer. The port will default to 8080, and you may override it with `process.env.PORT`.
 
-Consult `src/config.ts` for configuration, and `package.json` for environ variable setup.
+Consult [`src/config.ts`](./src/config.ts) for configuration, and [`package.json`](./package.json) for environment variable setup.
 
 ## Discord Chat
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Once saved, this will parse and load the environment variables from the .env fil
 
 Consult [`src/config.ts`](./src/config.ts) for configuration, and [`package.json`](./package.json) for more environment variable setup.
 
-To close the server for local ports, you may press `Ctrl` + `C`.
+To close the server for local ports, you may press `Ctrl` + `C` in the command line.
 
 ## Discord Chat
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,34 @@ This builds and runs the server.
 
 After running the server, content will be served at `localhost:PORT` on your computer. The port will default to 8080, and you may override it with `process.env.PORT`.
 
-Consult [`src/config.ts`](./src/config.ts) for configuration, and [`package.json`](./package.json) for environment variable setup.
+To change the port number for a temporary session, you can prepend `PORT=PortNumber` to your start command. Replace `PortNumber` with the port number you want. For example, to set the port number to 3000:
+```bash
+PORT=3000 yarn run server
+```
+
+Alternatively, you could configure the port number permanently with a new .env file:
+1. **Create a `.env` file** in your project's root directory.
+   
+2. **Open the `.env` file** and add the following line to specify the port:
+```bash
+PORT=PortNumber
+```
+Replace `PortNumber` with the port number you wish to use.
+
+3. **Save the file.** Your application needs to read this `.env` file and use its values. Ensure your server’s startup script or configuration is set up to parse `.env` files. Usually, this is done with libraries like `dotenv` in Node.js applications.
+
+4. **Install** `dotenv`. If it's not already installed, you can add it using [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm):
+```bash
+npm install dotenv
+```
+
+5. **Open the `index.js` File** and add the following line to the beginning of the file so that your project parses the environment variables before starting:
+```bash
+require('dotenv').config();
+```
+Once saved, this will parse and load the environment variables from the .env file and make them accessible via `process.env.PORT`.
+
+Consult [`src/config.ts`](./src/config.ts) for configuration, and [`package.json`](./package.json) for more environment variable setup.
 
 ## Discord Chat
 

--- a/src/Physics/QuadTree.ts
+++ b/src/Physics/QuadTree.ts
@@ -16,10 +16,6 @@
     along with this program. If not, see <https://www.gnu.org/licenses/>
 */
 
-/**
- * UNDOCUMENTED FILE
- **/
-
 import ObjectEntity from "../Entity/Object";
 import CollisionManager from "./CollisionManager";
 
@@ -53,8 +49,11 @@ class QuadTreeNode<T> {
         this.level = level;
     }
 
+    /** Inserting an object into a given range */
     protected _insert(object: Range<T>) {
         // {entity, x, y, radiW, radiH}
+        
+        // Check if current node is subdivided, then insert object into overlapping quadrants
         if (this.topLeft) {
             const top = object.y - object.radiH < this.y,
                 bottom = object.y + object.radiH > this.y,
@@ -74,6 +73,7 @@ class QuadTreeNode<T> {
 
         this.objects[this.objects.length] = object;
 
+        // Subdivide the object into 4 quadrants
         if (this.objects.length === 5 && this.level <= 9) {
             const halfW = this.radiW / 2,
                 halfH = this.radiH / 2,
@@ -147,7 +147,9 @@ class QuadTreeNode<T> {
         }
     }
 
+    /** Queries and retrieves all objects within a certain range */
     protected _retrieve(x: number, y: number, radiW: number, radiH: number): Range<T>[] {
+        // Check for subdivision, then retrieve objects from overlapping nodes
         if (this.topLeft) {
             let out: Range<T>[] = [];
             const top = y - radiH < this.y,
@@ -172,6 +174,7 @@ export default class DiepQuadTree extends QuadTreeNode<ObjectEntity> implements 
     public constructor(radiW: number, radiH: number) {
         super(0, 0, radiW, radiH, 0);
     }
+    /** Insert object based on entity dimensions */
     public insertEntity(entity: ObjectEntity) {
         this._insert({
             content: entity,
@@ -181,7 +184,7 @@ export default class DiepQuadTree extends QuadTreeNode<ObjectEntity> implements 
             radiH: entity.physicsData.values.sides === 2 ? entity.physicsData.values.width / 2 : entity.physicsData.values.size,
         });
     }
-
+    /** Retrieve list of entities that overlap parameter dimensions */
     public retrieve(x: number, y: number, radiW: number, radiH: number): ObjectEntity[] {
         const ranges = this._retrieve(x, y, radiW, radiH);
 
@@ -193,14 +196,14 @@ export default class DiepQuadTree extends QuadTreeNode<ObjectEntity> implements 
 
         return entities;
     }
-
+    /** Find entities in proximity to an ObjectEntity */
     public retrieveEntitiesByEntity(entity: ObjectEntity): ObjectEntity[] {
         return this.retrieve(entity.positionData.values.x,
             entity.positionData.values.y,
             entity.physicsData.values.sides === 2 ? entity.physicsData.values.size / 2 : entity.physicsData.values.size,
             entity.physicsData.values.sides === 2 ? entity.physicsData.values.width / 2 : entity.physicsData.values.size);
     }
-
+    /** Clear QuadTree data */
     public reset(bottomY: number, rightX: number) {
         this.bottomRight = this.bottomLeft = this.topLeft = this.topRight = null;
         this.radiW = rightX;

--- a/src/Physics/Velocity.ts
+++ b/src/Physics/Velocity.ts
@@ -16,9 +16,6 @@
     along with this program. If not, see <https://www.gnu.org/licenses/>
 */
 
-/**
- * UNDOCUMENTED FILE
- **/
 import Vector, { VectorAbstract } from "./Vector";
 
 export default class Velocity extends Vector {
@@ -26,11 +23,13 @@ export default class Velocity extends Vector {
     public position = new Vector();
     private firstTime = true;
 
+    /** Calcuates the velocity based on change in position */
     public updateVelocity() {
         this.x = this.position.x - this.previousPosition.x;
         this.y = this.position.y - this.previousPosition.y;
     }
 
+    /** Updates the current velocity and position */
     public setPosition(newPosition: VectorAbstract) {
         this.previousPosition.set(this.position);
         this.position.set(newPosition);


### PR DESCRIPTION
When I trying to create my own server, I wanted change my port number, but found the references to config.ts and package.json ambiguous. To increase accessibility for beginners like me, I added links to those files, as well as two possible ways to configure the port number. In addition, I added a quick instruction on how to close the server.
I also noticed that several .ts files were marked as "Undocumented". For QuadTree.ts and Velocity.ts, I added descriptions to explain method functionality based on the comment format found in the other Physics files.

